### PR TITLE
Added `--config` option and Windows fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,8 +46,7 @@ function defaultOptions(options) {
 }
 
 function buildArgs(file, options, done) {
-  var includes, jekyllCmd;
-  var args = arguments;
+  var includes, jekyllCmd, args = arguments;
 
   process.nextTick(function build() {
     if (!args.length) {
@@ -73,9 +72,15 @@ function buildArgs(file, options, done) {
       includes.push('safe');
     }
 
-    jekyllCmd = /win(32|64)/i.test(process.platform) ? 'jekyll.bat' : 'jekyll';
+    if(options.bundleExec) {
+      bund = ['bundle', 'exec'];
+      jekyllCmd = 'jekyll';
+    } else {
+      bund = [];
+      jekyllCmd = /win(32|64)/i.test(process.platform) ? 'jekyll.bat' : 'jekyll';
+    }
 
-    done(null, (options.bundleExec ? ['bundle', 'exec'] : [])
+    done(null, bund
       .concat([jekyllCmd, 'build'])
       .concat(dargs(options, {
         includes: includes

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function defaultOptions(options) {
 }
 
 function buildArgs(file, options, done) {
-  var includes;
+  var includes, jekyllCmd;
   var args = arguments;
 
   process.nextTick(function build() {
@@ -61,7 +61,8 @@ function buildArgs(file, options, done) {
       'source',
       'destination',
       'plugins',
-      'layouts'
+      'layouts',
+      'config'
     ];
 
     if (options.trace) {
@@ -72,8 +73,10 @@ function buildArgs(file, options, done) {
       includes.push('safe');
     }
 
+    jekyllCmd = /win(32|64)/i.test(process.platform) ? 'jekyll.bat' : 'jekyll';
+
     done(null, (options.bundleExec ? ['bundle', 'exec'] : [])
-      .concat(['jekyll', 'build'])
+      .concat([jekyllCmd, 'build'])
       .concat(dargs(options, {
         includes: includes
       })), options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,10 @@ function defaultOptions(options) {
 }
 
 function buildArgs(file, options, done) {
-  var includes, jekyllCmd, args = arguments;
+  var includes;
+  var jekyllCmd;
+  var bund;
+  var args = arguments;
 
   process.nextTick(function build() {
     if (!args.length) {
@@ -72,12 +75,14 @@ function buildArgs(file, options, done) {
       includes.push('safe');
     }
 
-    if(options.bundleExec) {
+    jekyllCmd = 'jekyll';
+    if (options.bundleExec) {
       bund = ['bundle', 'exec'];
-      jekyllCmd = 'jekyll';
     } else {
       bund = [];
-      jekyllCmd = /win(32|64)/i.test(process.platform) ? 'jekyll.bat' : 'jekyll';
+      if (/win(32|64)/i.test(process.platform)) {
+        jekyllCmd = 'jekyll.bat';
+      }
     }
 
     done(null, bund


### PR DESCRIPTION
- Added support to set Jekyll's config file (`--config` argument).
- Added fix to run on Windows.
